### PR TITLE
Koala-1245 | feat(convert-without-catalog):  init for convert without catalog

### DIFF
--- a/tests/yoda_dbt2looker/core/test_utils.py
+++ b/tests/yoda_dbt2looker/core/test_utils.py
@@ -4,8 +4,8 @@ import json
 import yaml
 from pathlib import Path
 from unittest.mock import mock_open, patch
-from yoda_dbt2looker.core import utils
 from yoda_dbt2looker.core.config import config
+from yoda_dbt2looker.core import utils
 
 
 class TestUtils:
@@ -29,7 +29,7 @@ class TestUtils:
     def test_configure_logging_default(self, mock_basicConfig):
         utils.configure_logging()
         mock_basicConfig.assert_called_once_with(
-            level=getattr(logging, config.DEFAULT_LOG_LEVEL),
+            level=getattr(logging, config.LOG_LEVEL),
             format='%(asctime)s %(levelname)-6s %(message)s',
             datefmt='%H:%M:%S',
         )
@@ -62,14 +62,14 @@ class TestUtils:
         result = utils.load_yaml_file(Path("dummy_path.yml"))
         assert result == {"key": "value"}
 
-    @patch("yoda_dbt2looker.utils.load_json_file")
+    @patch("yoda_dbt2looker.core.utils.load_json_file")
     @patch("yoda_dbt2looker.parser.validate_manifest")
     def test_get_manifest(self, mock_validate_manifest, mock_load_json_file, mock_manifest):
         mock_load_json_file.return_value = mock_manifest
         result = utils.get_manifest("dummy_prefix")
         assert result == mock_manifest
 
-    @patch("yoda_dbt2looker.utils.load_yaml_file")
+    @patch("yoda_dbt2looker.core.utils.load_yaml_file")
     def test_get_dbt_project_config(self, mock_load_yaml_file, mock_dbt_project):
         mock_load_yaml_file.return_value = mock_dbt_project
         result = utils.get_dbt_project_config("dummy_prefix")
@@ -85,12 +85,12 @@ class TestUtils:
         with pytest.raises(SystemExit):
             utils.load_yaml_file(Path("dummy_path.yml"))
 
-    @patch("yoda_dbt2looker.utils.load_json_file", side_effect=SystemExit)
+    @patch("yoda_dbt2looker.core.utils.load_json_file", side_effect=SystemExit)
     def test_get_manifest_file_not_found(self, mock_load_json_file):
         with pytest.raises(SystemExit):
             utils.get_manifest("dummy_prefix")
 
-    @patch("yoda_dbt2looker.utils.load_yaml_file", side_effect=SystemExit)
+    @patch("yoda_dbt2looker.core.utils.load_yaml_file", side_effect=SystemExit)
     def test_get_dbt_project_config_file_not_found(self, mock_load_yaml_file):
         with pytest.raises(SystemExit):
             utils.get_dbt_project_config("dummy_prefix")

--- a/yoda_dbt2looker/core/__init__.py
+++ b/yoda_dbt2looker/core/__init__.py
@@ -1,0 +1,8 @@
+from .utils import configure_logging
+from .config import config
+
+# Configure logging when the package is imported
+configure_logging(config.LOG_LEVEL)
+
+# Import other necessary modules or functions
+from .converter import convert

--- a/yoda_dbt2looker/core/config.py
+++ b/yoda_dbt2looker/core/config.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Config:
+    LOOKML_OUTPUT_DIR: str = './lookml'
+    TARGET_DIR: str = './target'
+    PROJECT_DIR: str = './'
+    LOG_LEVEL: str = 'INFO'
+    MANIFEST_FILENAME: str = 'manifest.json'
+    DBT_PROJECT_FILENAME: str = 'dbt_project.yml'
+
+
+config = Config()

--- a/yoda_dbt2looker/core/converter.py
+++ b/yoda_dbt2looker/core/converter.py
@@ -1,0 +1,58 @@
+import logging
+from typing import List, Dict, Any, Optional
+
+from .utils import (
+    get_manifest,
+    get_dbt_project_config
+)
+from .config import config
+from ..models import (
+    DbtModel,
+    DbtProjectConfig,
+)
+from ..parser import parse_dbt_project_config, parse_adapter_type
+from yoda_dbt2looker.core.parser import parse_typed_models
+
+
+def convert(target_dir=config.TARGET_DIR, project_dir=config.PROJECT_DIR, output_dir=config.LOOKML_OUTPUT_DIR, tag=None):
+    """
+    Convert dbt models to LookML views and models.
+
+    This function performs the following steps:
+    1. Retrieves the dbt manifest and project configuration
+    2. Parses the dbt project config and models
+    3. Determines the adapter type from the manifest
+    4. Generates LookML views from the parsed dbt models
+    5. Generates LookML models from the parsed dbt models
+
+    Args:
+        target_dir (str): Directory containing the dbt target files (default: config.TARGET_DIR)
+        project_dir (str): Directory containing the dbt project files (default: config.PROJECT_DIR)
+        output_dir (str): Directory to output the generated LookML files (default: config.LOOKML_OUTPUT_DIR)
+        tag (str, optional): Tag to filter dbt models (default: None)
+
+    Returns:
+        None
+
+    Raises:
+        SystemExit: If there's an error in loading or parsing the dbt files
+    """
+    raw_manifest = get_manifest(prefix=target_dir)
+    raw_config = get_dbt_project_config(prefix=project_dir)
+
+    dbt_project_config = parse_dbt_project_config(raw_config)
+    typed_dbt_models = parse_typed_models(raw_manifest, dbt_project_config.name, tag=tag)
+    adapter_type = parse_adapter_type(raw_manifest)
+
+    _generate_lookml_views(typed_dbt_models, adapter_type, output_dir)
+    _generate_lookml_models(raw_manifest, typed_dbt_models, dbt_project_config, tag, output_dir)
+    logging.info('Convertion finished successfully')
+
+
+def _generate_lookml_views(typed_dbt_models: List[DbtModel], adapter_type: str, output_dir: str) -> None:
+    pass
+
+
+def _generate_lookml_models(raw_manifest: Dict[str, Any], typed_dbt_models: List[DbtModel],
+                            dbt_project_config: DbtProjectConfig, tag: Optional[str], output_dir: str) -> None:
+    pass

--- a/yoda_dbt2looker/core/converter.py
+++ b/yoda_dbt2looker/core/converter.py
@@ -45,7 +45,6 @@ def convert(target_dir=config.TARGET_DIR, project_dir=config.PROJECT_DIR, output
     adapter_type = parse_adapter_type(raw_manifest)
 
     _generate_lookml_views(typed_dbt_models, adapter_type, output_dir)
-    _generate_lookml_models(raw_manifest, typed_dbt_models, dbt_project_config, tag, output_dir)
     logging.info('Convertion finished successfully')
 
 
@@ -53,6 +52,3 @@ def _generate_lookml_views(typed_dbt_models: List[DbtModel], adapter_type: str, 
     pass
 
 
-def _generate_lookml_models(raw_manifest: Dict[str, Any], typed_dbt_models: List[DbtModel],
-                            dbt_project_config: DbtProjectConfig, tag: Optional[str], output_dir: str) -> None:
-    pass

--- a/yoda_dbt2looker/core/parser.py
+++ b/yoda_dbt2looker/core/parser.py
@@ -1,0 +1,36 @@
+import logging
+from typing import Optional
+from functools import reduce
+
+from ..parser import (
+    parse_models,
+    check_models_for_missing_column_types,
+)
+
+
+def parse_typed_models(
+        raw_manifest: dict,
+        tag: Optional[str] = None,
+):
+    dbt_models = parse_models(raw_manifest, tag=tag)
+    logging.debug("Parsed %d models from manifest.json", len(dbt_models))
+    if logging.getLogger().isEnabledFor(logging.DEBUG):
+        for model in dbt_models:
+            logging.debug(
+                "Model %s has %d columns with %d measures",
+                model.name,
+                len(model.columns),
+                reduce(
+                    lambda acc, col: acc
+                                     + len(col.meta.measures)
+                                     + len(col.meta.measure)
+                                     + len(col.meta.metrics)
+                                     + len(col.meta.metric),
+                    model.columns.values(),
+                    0,
+                ),
+            )
+
+    logging.debug("Found manifest entries for %d models", len(dbt_models))
+    check_models_for_missing_column_types(dbt_models)
+    return dbt_models

--- a/yoda_dbt2looker/core/utils.py
+++ b/yoda_dbt2looker/core/utils.py
@@ -10,10 +10,22 @@ try:
 except ImportError:
     from yaml import Loader
 
-from . import parser
+from .. import parser
 
-MANIFEST_FILENAME = 'manifest.json'
-DBT_PROJECT_FILENAME = 'dbt_project.yml'
+from config import config
+
+
+def configure_logging(log_level: str = config.DEFAULT_LOG_LEVEL):
+    logging.basicConfig(
+        level=getattr(logging, log_level),
+        format='%(asctime)s %(levelname)-6s %(message)s',
+        datefmt='%H:%M:%S',
+    )
+
+
+def write_lookml_file(file_path: str, contents: str) -> None:
+    with open(file_path, 'w') as f:
+        f.write(contents)
 
 
 def load_json_file(file_path: Path) -> Dict[str, Any]:
@@ -35,7 +47,7 @@ def load_yaml_file(file_path: Path) -> Dict[str, Any]:
 
 
 def get_manifest(prefix: str) -> Dict[str, Any]:
-    manifest_path = os.path.join(prefix, MANIFEST_FILENAME)
+    manifest_path = os.path.join(prefix, config.MANIFEST_FILENAME)
     raw_manifest = load_json_file(manifest_path)
     parser.validate_manifest(raw_manifest)
     logging.debug(f'Detected valid manifest at {manifest_path}')
@@ -43,7 +55,7 @@ def get_manifest(prefix: str) -> Dict[str, Any]:
 
 
 def get_dbt_project_config(prefix: str) -> Dict[str, Any]:
-    project_path = os.path.join(prefix, DBT_PROJECT_FILENAME)
+    project_path = os.path.join(prefix, config.DBT_PROJECT_FILENAME)
     project_config = load_yaml_file(project_path)
     logging.debug(f'Detected valid dbt config at {project_path}')
     return project_config

--- a/yoda_dbt2looker/core/utils.py
+++ b/yoda_dbt2looker/core/utils.py
@@ -12,10 +12,10 @@ except ImportError:
 
 from .. import parser
 
-from config import config
+from .config import config
 
 
-def configure_logging(log_level: str = config.DEFAULT_LOG_LEVEL):
+def configure_logging(log_level: str = config.LOG_LEVEL):
     logging.basicConfig(
         level=getattr(logging, log_level),
         format='%(asctime)s %(levelname)-6s %(message)s',


### PR DESCRIPTION
# Context
As part of the new implementation for semantic layer we will convert gold DBT models in looker views.
In this project we will add new implementation which won't use : catalog object & Yoda exposures .
In order to support both new and current implementation we will store the new implementation under internal `core` package .

# Changes
- created `core` package
- moved `utils` under new package
- added `config` class which will contain all constants
- added `converter` module which will contain the convert command