### PR TITLE
add support to new iceberg tag

### DIFF
--- a/tests/yoda_dbt2looker/core/test_core_generator.py
+++ b/tests/yoda_dbt2looker/core/test_core_generator.py
@@ -58,6 +58,23 @@ class TestGenerator:
         result = generator.get_model_relation_name(mock_dbt_model)
         assert result == "test_schema.test_table"
 
+        mock_dbt_model = MagicMock(spec=DbtModel)
+        mock_dbt_model.tags = [config.YODA_SNOWFLAKE_AS_ICEBERG_TAG]
+        mock_dbt_model.meta = mock_meta
+
+        result = generator.get_model_relation_name(mock_dbt_model)
+        assert result == "test_schema.test_table"
+
+        mock_dbt_model = MagicMock(spec=DbtModel)
+        mock_dbt_model.tags = []
+        mock_dbt_model.relation_name = "relation_name"
+
+        result = generator.get_model_relation_name(mock_dbt_model)
+        assert result == "relation_name"
+
+
+
+
     def test_get_model_relation_name_without_tag(self):
         mock_dbt_model = MagicMock(spec=DbtModel)
         mock_dbt_model.tags = []

--- a/yoda_dbt2looker/core/config.py
+++ b/yoda_dbt2looker/core/config.py
@@ -10,6 +10,7 @@ class Config:
     MANIFEST_FILENAME: str = 'manifest.json'
     DBT_PROJECT_FILENAME: str = 'dbt_project.yml'
     YODA_SNOWFLAKE_TAG: str = 'yoda_snowflake'
+    YODA_SNOWFLAKE_AS_ICEBERG_TAG: str = 'yoda_snowflake_as_iceberg'
 
 
 config = Config()

--- a/yoda_dbt2looker/core/generator.py
+++ b/yoda_dbt2looker/core/generator.py
@@ -50,7 +50,7 @@ def lookml_view_from_dbt_model(model: DbtModel, adapter_type: SupportedDbtAdapte
 
 
 def get_model_relation_name(model: DbtModel):
-    if config.YODA_SNOWFLAKE_TAG in model.tags:
+    if config.YODA_SNOWFLAKE_TAG in model.tags or config.YODA_SNOWFLAKE_AS_ICEBERG_TAG in model.tags:
         return f"{model.meta.integration_config.snowflake.properties.sf_schema}.{model.meta.integration_config.snowflake.properties.table}"
     return model.relation_name
 


### PR DESCRIPTION
**Context**

Part of [KOALA-1777](https://yotpoent.atlassian.net/browse/KOALA-1777)

This PR introduces the new snowflake export via iceberg tag.
It applies the same relation name behavior as done before on models tagged as exported to snowflake.

[KOALA-1777]: https://yotpoent.atlassian.net/browse/KOALA-1777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ