### PR TITLE
preserve migrated views names

### DIFF
--- a/yoda_dbt2looker/core/generator.py
+++ b/yoda_dbt2looker/core/generator.py
@@ -26,9 +26,10 @@ def generate_lookml_views(dbt_models: List[DbtModel], adapter_type: str, output_
 
 
 def lookml_view_from_dbt_model(model: DbtModel, adapter_type: SupportedDbtAdapters) -> LookViewFile:
+    view_name = model.name if not model.meta.migrated_from_model else model.meta.migrated_from_model
     lookml = {
         "view": {
-            "name": model.name,
+            "name": view_name,
             "sql_table_name": get_model_relation_name(model),
             "dimension_groups": lookml_dimension_groups_from_model(model, adapter_type),
             "dimensions": lookml_dimensions_from_model(model, adapter_type),
@@ -37,7 +38,8 @@ def lookml_view_from_dbt_model(model: DbtModel, adapter_type: SupportedDbtAdapte
         }
     }
     logging.debug(
-        f"Created view from model %s with %d dimensions",
+        f"Created view %s from model %s with %d dimensions",
+        view_name,
         model.name,
         len(lookml["view"]["dimensions"]),
     )
@@ -46,7 +48,7 @@ def lookml_view_from_dbt_model(model: DbtModel, adapter_type: SupportedDbtAdapte
     except Exception as e:
         logging.error(f"Error dumping lookml for model {model.name}")
         raise e
-    return LookViewFile(filename=f"{model.name}.view.lkml", contents=contents)
+    return LookViewFile(filename=f"{view_name}.view.lkml", contents=contents)
 
 
 def get_model_relation_name(model: DbtModel):

--- a/yoda_dbt2looker/core/generator.py
+++ b/yoda_dbt2looker/core/generator.py
@@ -26,7 +26,7 @@ def generate_lookml_views(dbt_models: List[DbtModel], adapter_type: str, output_
 
 
 def lookml_view_from_dbt_model(model: DbtModel, adapter_type: SupportedDbtAdapters) -> LookViewFile:
-    view_name = model.name if not model.meta.migrated_from_model else model.meta.migrated_from_model
+    view_name = model.meta.migrated_from_model or model.name
     lookml = {
         "view": {
             "name": view_name,

--- a/yoda_dbt2looker/core/models.py
+++ b/yoda_dbt2looker/core/models.py
@@ -17,6 +17,7 @@ from yoda_dbt2looker.models import (
 class DbtModelMeta(BaseModel):
     primary_key: Optional[str] = Field(None, alias="primary-key")
     integration_config: Optional[ModelIntegrationConfigMetadata] = None
+    migrated_from_model: Optional[str] = Field(None, alias="migrated-from-model")
 
 
 class DbtModelConfig(BaseModel):


### PR DESCRIPTION
**Context**

Part of [1777](https://yotpoent.atlassian.net/browse/KOALA-1777)

In case the exported dbt model contains the metadata migrated_from_model, the Looker view created will hold the name of the migrated model to avoid breaking changes of consumers