### PR TITLE
Fix the property name of the iceberg integration config

### DIFF
--- a/tests/yoda_dbt2looker/core/test_core_generator.py
+++ b/tests/yoda_dbt2looker/core/test_core_generator.py
@@ -63,6 +63,7 @@ class TestGenerator:
         mock_snowflake_properties = MagicMock()
         mock_snowflake_properties.sf_schema = "test_schema"
         mock_snowflake_properties.table = "test_table"
+        mock_snowflake_properties.SF_TABLE_NAME = "test_table_sf"
 
         mock_snowflake_integration = MagicMock()
         mock_snowflake_integration.properties = mock_snowflake_properties
@@ -85,7 +86,7 @@ class TestGenerator:
         mock_dbt_model.meta = mock_meta
 
         result = generator.get_model_relation_name(mock_dbt_model)
-        assert result == "test_schema.test_table"
+        assert result == "test_schema.test_table_sf"
 
         mock_dbt_model = MagicMock(spec=DbtModel)
         mock_dbt_model.tags = []

--- a/yoda_dbt2looker/core/generator.py
+++ b/yoda_dbt2looker/core/generator.py
@@ -52,8 +52,10 @@ def lookml_view_from_dbt_model(model: DbtModel, adapter_type: SupportedDbtAdapte
 
 
 def get_model_relation_name(model: DbtModel):
-    if config.YODA_SNOWFLAKE_TAG in model.tags or config.YODA_SNOWFLAKE_AS_ICEBERG_TAG in model.tags:
+    if config.YODA_SNOWFLAKE_TAG in model.tags :
         return f"{model.meta.integration_config.snowflake.properties.sf_schema}.{model.meta.integration_config.snowflake.properties.table}"
+    if config.YODA_SNOWFLAKE_AS_ICEBERG_TAG in model.tags:
+        return f"{model.meta.integration_config.snowflake.properties.sf_schema}.{model.meta.integration_config.snowflake.properties.SF_TABLE_NAME}"
     return model.relation_name
 
 


### PR DESCRIPTION
**Context**

Part of [KOALA-1777](https://yotpoent.atlassian.net/browse/KOALA-1777)

Fix the property name of the snowflake table of the iceberg integrations

[KOALA-1777]: https://yotpoent.atlassian.net/browse/KOALA-1777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ