### PR TITLE
Koala 1777 add timestamp ntz type

### DIFF
--- a/tests/yoda_dbt2looker/test_generator.py
+++ b/tests/yoda_dbt2looker/test_generator.py
@@ -677,3 +677,18 @@ def test__generate_view_label_if_needed():
     model.model_labels.model_label = "label1"
     generator._generate_view_label_if_needed(model, lookml)
     assert lookml == {"view": {"label": "label1"}}
+
+def test_map_adapter_type_to_looker_timestamp_ntz():
+    # Test spark adapter timestamp_ntz conversion
+    looker_type = generator.map_adapter_type_to_looker(
+        models.SupportedDbtAdapters.spark.value, 
+        "timestamp_ntz"
+    )
+    assert looker_type == "timestamp"
+
+    # Test databricks adapter timestamp_ntz conversion  
+    looker_type = generator.map_adapter_type_to_looker(
+        models.SupportedDbtAdapters.databricks.value,
+        "timestamp_ntz"
+    )
+    assert looker_type == "timestamp"

--- a/yoda_dbt2looker/generator.py
+++ b/yoda_dbt2looker/generator.py
@@ -174,6 +174,7 @@ LOOKER_DTYPE_MAP = {
         "boolean": "yesno",
         "timestamp": "timestamp",
         "date": "datetime",
+        "timestamp_ntz": "timestamp",
     },
     "databricks": {
         "byte": "number",
@@ -192,6 +193,7 @@ LOOKER_DTYPE_MAP = {
         "boolean": "yesno",
         "timestamp": "timestamp",
         "date": "datetime",
+        "timestamp_ntz": "timestamp",
     },
 }
 


### PR DESCRIPTION
**Context**
part of [KOALA-1777](https://yotpoent.atlassian.net/browse/KOALA-1777)
Enable type mapping for timestamp_ntz for databricks and spark adapters

[KOALA-1777]: https://yotpoent.atlassian.net/browse/KOALA-1777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ